### PR TITLE
fix: correctness, robustness, and stability bugs across FastLSQ

### DIFF
--- a/examples/orbit_hill.py
+++ b/examples/orbit_hill.py
@@ -31,7 +31,6 @@ import sys
 import time
 import numpy as np
 import torch
-from scipy.linalg import cho_factor, cho_solve
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from fastlsq.basis import SinusoidalBasis  # noqa: E402
@@ -166,10 +165,13 @@ def assemble(basis: SinusoidalBasis, pts_int: torch.Tensor):
 def solve(A, b):
     A64 = A.astype(np.float64, copy=False)
     b64 = b.astype(np.float64, copy=False)
-    AtA = A64.T @ A64 + MU_REG * np.eye(A64.shape[1])
-    Atb = A64.T @ b64
-    cho = cho_factor(AtA)
-    return cho_solve(cho, Atb)
+    # Rank-revealing least squares. Forming the normal equations A^T A (+ridge)
+    # and Cholesky-factoring them squares the condition number of this
+    # random-feature system, which made cho_factor fail ("not positive
+    # definite"); lstsq solves min ||A x - b|| directly via SVD and needs no
+    # positive-definiteness.
+    beta, *_ = np.linalg.lstsq(A64, b64, rcond=None)
+    return beta
 
 
 # ---------------------------------------------------------------------------

--- a/fastlsq/api.py
+++ b/fastlsq/api.py
@@ -174,8 +174,8 @@ def solve_nonlinear(
     n_bc: int = 1000,
     n_test: int = 5000,
     max_iter: int = 30,
-    tol_res: float = 1e-12,
-    tol_du: float = 1e-13,
+    tol_res: float = 1e-8,
+    tol_du: float = 1e-10,
     damping: float = 1.0,
     mu: float = 1e-10,
     auto_scale: bool = True,
@@ -264,9 +264,11 @@ def solve_nonlinear(
     # Check for continuation
     if getattr(problem, "use_continuation", False):
         schedule = list(problem.continuation_schedule)
-        if schedule[-1] != getattr(problem, "nu_target", None):
-            schedule.append(getattr(problem, "nu_target", None))
-        schedule = [v for v in schedule if v >= getattr(problem, "nu_target", 0.0)]
+        nu_target = getattr(problem, "nu_target", None)
+        if nu_target is not None:
+            if schedule[-1] != nu_target:
+                schedule.append(nu_target)
+            schedule = [v for v in schedule if v >= nu_target]
 
         history = continuation_solve(
             solver, problem, x_pde, bcs, f_pde,

--- a/fastlsq/basis.py
+++ b/fastlsq/basis.py
@@ -172,6 +172,11 @@ class SinusoidalBasis:
 
     def cache(self, x: torch.Tensor) -> BasisCache:
         """Create a cache for the given collocation points."""
+        # Accept inputs in any dtype/device (e.g. float32 from user code) and
+        # promote to the basis's own dtype/device so ``x @ self.W`` never trips
+        # a float32-vs-float64 mismatch.
+        if x.dtype != self.W.dtype or x.device != self.W.device:
+            x = x.to(dtype=self.W.dtype, device=self.W.device)
         return BasisCache(x @ self.W + self.b)
 
     # ------------------------------------------------------------------

--- a/fastlsq/export.py
+++ b/fastlsq/export.py
@@ -164,7 +164,10 @@ def load_checkpoint(
     solver : FastLSQSolver
     metadata : dict, optional
     """
-    state = torch.load(path, map_location=device)
+    # weights_only=False: save_checkpoint writes NumPy arrays (see to_dict),
+    # which torch>=2.6's default weights_only=True refuses to unpickle. The
+    # file is produced by this library, so it is trusted.
+    state = torch.load(path, map_location=device, weights_only=False)
     metadata = state.pop("metadata", None)
     solver = from_dict(state, device=device)
     return solver, metadata

--- a/fastlsq/learnable.py
+++ b/fastlsq/learnable.py
@@ -180,19 +180,26 @@ class LearnableFastLSQ(nn.Module):
                     rcond: float = 1e-12):
         """Differentiable rank-revealing inner solve.
 
-        Solves ``beta* = argmin ||A beta - b||^2 + mu ||beta||^2`` through a
-        rank-revealing truncated SVD of ``A``, so gradients still flow back to
-        ``L`` *and* the solve is stable when ``A`` is rank-deficient.  (The plain
-        ``torch.linalg.lstsq`` used previously amplifies the near-null space and
-        makes the outer AdamW loop diverge.)
+        Solves ``beta* = argmin ||A beta - b||^2 + mu ||beta||^2`` through the
+        SVD-based ``gelsd`` least-squares driver with ``rcond`` truncation, so
+        gradients still flow back to ``L`` *and* the solve is stable when ``A``
+        is rank-deficient.  (The ``rcond`` cut suppresses the near-null space,
+        and ``gelsd``'s backward uses the stable pseudoinverse formula rather
+        than per-singular-vector derivatives -- which is what keeps the outer
+        AdamW loop's gradients finite.  A plain ``torch.linalg.lstsq`` *without*
+        ``rcond`` is what amplifies the null space.)
 
         For ``n_outputs > 1`` the system is block-stacked: the flat solution is
         kept as ``self._beta_flat`` (shape-compatible with ``A``) for residual
         losses, while ``self.beta`` is reshaped to ``(N, k)`` for prediction.
         """
-        U, S, Vh = torch.linalg.svd(A, full_matrices=False)
-        filt = torch.where(S > rcond * S[0], S / (S * S + mu), torch.zeros_like(S))
-        beta_flat = Vh.transpose(-2, -1) @ (filt.unsqueeze(-1) * (U.transpose(-2, -1) @ b))
+        if mu and mu > 0.0:
+            n = A.shape[-1]
+            A_aug = torch.cat([A, (mu ** 0.5) * torch.eye(n, dtype=A.dtype, device=A.device)], dim=0)
+            b_aug = torch.cat([b, torch.zeros(n, b.shape[-1], dtype=b.dtype, device=b.device)], dim=0)
+            beta_flat = torch.linalg.lstsq(A_aug, b_aug, rcond=rcond, driver="gelsd").solution
+        else:
+            beta_flat = torch.linalg.lstsq(A, b, rcond=rcond, driver="gelsd").solution
         self._beta_flat = beta_flat
         if self.n_outputs > 1:
             self.beta = unpack_beta(beta_flat, self.n_features, self.n_outputs)

--- a/fastlsq/linalg.py
+++ b/fastlsq/linalg.py
@@ -92,7 +92,7 @@ def _auto_solve(A, b, mu, rcond):
     try:
         x, L = _cholesky_solve(A, b, mu)
         d = torch.diagonal(L).abs()
-        if torch.isfinite(d).all() and d.min() > (rcond ** 0.5) * d.max():
+        if torch.isfinite(d).all() and d.min() > (rcond ** 0.25) * d.max():
             return x
     except torch.linalg.LinAlgError:
         pass

--- a/fastlsq/newton.py
+++ b/fastlsq/newton.py
@@ -87,10 +87,13 @@ def newton_solve(solver, problem, x_pde, bcs, f_pde,
     history = []
     n_outputs = getattr(problem, "n_outputs", 1)
     N = solver.n_features
+    R0 = None
 
     for it in range(max_iter):
         J, neg_R = problem.build_newton_step(solver, x_pde, bcs, f_pde)
         res_norm = torch.norm(neg_R).item()
+        if R0 is None:
+            R0 = max(res_norm, 1e-30)
 
         delta_beta_raw = solve_lstsq(J, neg_R, mu=mu)
         delta_beta = unpack_beta(delta_beta_raw, N, n_outputs)
@@ -116,7 +119,10 @@ def newton_solve(solver, problem, x_pde, bcs, f_pde,
                 break
             alpha *= 0.5
         else:
-            solver.beta = beta_old + alpha * delta_beta
+            # No backtracked step satisfied the Armijo condition; reject the
+            # step and keep the previous iterate rather than committing a
+            # point that may be worse than where we started.
+            solver.beta = beta_old
 
         history.append({
             "iter": it, "residual": res_norm,
@@ -128,7 +134,7 @@ def newton_solve(solver, problem, x_pde, bcs, f_pde,
             print(f"  Newton {it:2d}: |R|={res_norm:.2e}  "
                   f"|du|/|u|={rel_du:.2e}  alpha={alpha:.3f}")
 
-        if res_norm < tol_res and rel_du < tol_du:
+        if res_norm < tol_res * R0 or rel_du < tol_du:
             if verbose:
                 print(f"  Converged in {it + 1} iterations "
                       f"(|R|={res_norm:.1e}, |du|/|u|={rel_du:.1e})")

--- a/fastlsq/problems/linear.py
+++ b/fastlsq/problems/linear.py
@@ -392,13 +392,13 @@ class ElasticWave2D:
         # t is normalised to [0,1]; physical d²/dt² = (1/t_max)² d²/dτ²
         t_scale = self.t_max ** 2
 
-        # PDE1: u_x_tt - c_p² u_x_xx - c_s² u_x_yy - (c_p² - c_s²) u_y_xy = 0
-        A1_x = t_scale * u_tt - self.c_p2 * u_xx - self.c_s2 * u_yy
-        A1_y = -self.c_cross * u_xy
+        # PDE1: u_x_ττ = t_max²·(c_p² u_x_xx + c_s² u_x_yy + (c_p²-c_s²) u_y_xy)
+        A1_x = u_tt - t_scale * (self.c_p2 * u_xx + self.c_s2 * u_yy)
+        A1_y = -t_scale * self.c_cross * u_xy
 
-        # PDE2: u_y_tt - c_p² u_y_yy - c_s² u_y_xx - (c_p² - c_s²) u_x_xy = 0
-        A2_x = -self.c_cross * u_xy
-        A2_y = t_scale * u_tt - self.c_p2 * u_yy - self.c_s2 * u_xx
+        # PDE2: u_y_ττ = t_max²·(c_p² u_y_yy + c_s² u_y_xx + (c_p²-c_s²) u_x_xy)
+        A2_x = -t_scale * self.c_cross * u_xy
+        A2_y = u_tt - t_scale * (self.c_p2 * u_yy + self.c_s2 * u_xx)
 
         A_pde = torch.cat([
             torch.cat([A1_x, A1_y], dim=1),

--- a/fastlsq/problems/nonlinear.py
+++ b/fastlsq/problems/nonlinear.py
@@ -17,7 +17,7 @@ Each class provides:
 import torch
 import numpy as np
 
-from fastlsq.utils import device
+from fastlsq.device import get_device
 
 
 # ======================================================================
@@ -27,9 +27,9 @@ from fastlsq.utils import device
 def _unit_square_boundary(n_bc):
     """Generate n_bc random points on the boundary of [0,1]^2."""
     n_side = n_bc // 4
-    r = lambda n: torch.rand(n, 1, device=device)
-    z = lambda n: torch.zeros(n, 1, device=device)
-    o = lambda n: torch.ones(n, 1, device=device)
+    r = lambda n: torch.rand(n, 1, device=get_device())
+    z = lambda n: torch.zeros(n, 1, device=get_device())
+    o = lambda n: torch.ones(n, 1, device=get_device())
     return torch.cat([
         torch.cat([z(n_side), r(n_side)], 1),
         torch.cat([o(n_side), r(n_side)], 1),
@@ -68,7 +68,7 @@ class NLPoisson2D:
         return 2 * np.pi ** 2 * u + u ** 3
 
     def get_train_data(self, n_pde=5000, n_bc=1000):
-        x_pde = torch.rand(n_pde, 2, device=device)
+        x_pde = torch.rand(n_pde, 2, device=get_device())
         f_pde = self.source(x_pde)
         x_bc = _unit_square_boundary(n_bc)
         u_bc = self.exact(x_bc)
@@ -102,7 +102,7 @@ class NLPoisson2D:
         return torch.cat(rows_A, 0), torch.cat(rows_b, 0)
 
     def get_test_points(self, n=5000):
-        return torch.rand(n, 2, device=device)
+        return torch.rand(n, 2, device=get_device())
 
 
 # ======================================================================
@@ -136,7 +136,7 @@ class Bratu2D:
         return 2 * np.pi ** 2 * u - self.lam * torch.exp(u)
 
     def get_train_data(self, n_pde=5000, n_bc=1000):
-        x_pde = torch.rand(n_pde, 2, device=device)
+        x_pde = torch.rand(n_pde, 2, device=get_device())
         f_pde = self.source(x_pde)
         x_bc = _unit_square_boundary(n_bc)
         u_bc = self.exact(x_bc)
@@ -171,7 +171,7 @@ class Bratu2D:
         return torch.cat(rows_A, 0), torch.cat(rows_b, 0)
 
     def get_test_points(self, n=5000):
-        return torch.rand(n, 2, device=device)
+        return torch.rand(n, 2, device=get_device())
 
 
 # ======================================================================
@@ -207,13 +207,13 @@ class SteadyBurgers1D:
         return u * ux - self.nu * uxx
 
     def get_train_data(self, n_pde=3000, n_bc=200):
-        x_pde = torch.rand(n_pde, 1, device=device)
+        x_pde = torch.rand(n_pde, 1, device=get_device())
         f_pde = self.source(x_pde)
         x_bc = torch.cat([
-            torch.zeros(n_bc // 2, 1, device=device),
-            torch.ones(n_bc // 2, 1, device=device),
+            torch.zeros(n_bc // 2, 1, device=get_device()),
+            torch.ones(n_bc // 2, 1, device=get_device()),
         ], 0)
-        u_bc = torch.zeros(n_bc, 1, device=device)
+        u_bc = torch.zeros(n_bc, 1, device=get_device())
         return x_pde, [(x_bc, u_bc)], f_pde
 
     def build_newton_step(self, solver, x_pde, bcs, f_pde):
@@ -249,7 +249,7 @@ class SteadyBurgers1D:
         return torch.cat(rows_A, 0), torch.cat(rows_b, 0)
 
     def get_test_points(self, n=5000):
-        return torch.rand(n, 1, device=device)
+        return torch.rand(n, 1, device=get_device())
 
 
 # ======================================================================
@@ -285,7 +285,7 @@ class NLHelmholtz2D:
         return -self.k ** 2 * u + self.alpha * u ** 3
 
     def get_train_data(self, n_pde=5000, n_bc=1000):
-        x_pde = torch.rand(n_pde, 2, device=device)
+        x_pde = torch.rand(n_pde, 2, device=get_device())
         f_pde = self.source(x_pde)
         x_bc = _unit_square_boundary(n_bc)
         u_bc = self.exact(x_bc)
@@ -321,7 +321,7 @@ class NLHelmholtz2D:
         return torch.cat(rows_A, 0), torch.cat(rows_b, 0)
 
     def get_test_points(self, n=5000):
-        return torch.rand(n, 2, device=device)
+        return torch.rand(n, 2, device=get_device())
 
 
 # ======================================================================
@@ -352,13 +352,13 @@ class AllenCahn1D:
         return self.eps * uxx + u - u ** 3
 
     def get_train_data(self, n_pde=3000, n_bc=200):
-        x_pde = torch.rand(n_pde, 1, device=device)
+        x_pde = torch.rand(n_pde, 1, device=get_device())
         f_pde = self.source(x_pde)
         x_bc = torch.cat([
-            torch.zeros(n_bc // 2, 1, device=device),
-            torch.ones(n_bc // 2, 1, device=device),
+            torch.zeros(n_bc // 2, 1, device=get_device()),
+            torch.ones(n_bc // 2, 1, device=get_device()),
         ], 0)
-        u_bc = torch.zeros(n_bc, 1, device=device)
+        u_bc = torch.zeros(n_bc, 1, device=get_device())
         return x_pde, [(x_bc, u_bc)], f_pde
 
     def build_newton_step(self, solver, x_pde, bcs, f_pde):
@@ -393,4 +393,4 @@ class AllenCahn1D:
         return torch.cat(rows_A, 0), torch.cat(rows_b, 0)
 
     def get_test_points(self, n=5000):
-        return torch.rand(n, 1, device=device)
+        return torch.rand(n, 1, device=get_device())

--- a/fastlsq/problems/regression.py
+++ b/fastlsq/problems/regression.py
@@ -14,7 +14,7 @@ avoid code duplication.
 import torch
 import numpy as np
 
-from fastlsq.utils import device
+from fastlsq.device import get_device
 from fastlsq.problems.nonlinear import Bratu2D, NLHelmholtz2D
 
 
@@ -60,8 +60,8 @@ class Burgers1D_Regression:
         dz_dt = -0.5 / (4 * self.nu)
         return torch.cat([du_dz * dz_dx, du_dz * dz_dt], dim=1)
 
-    def get_train_data(self, n_samples=5000):
-        x_pde = torch.rand(n_samples, 2, device=device)
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_pde = torch.rand(n_pde, 2, device=get_device())
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
 
@@ -69,7 +69,7 @@ class Burgers1D_Regression:
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=10000):
-        return torch.rand(n, self.dim, device=device)
+        return torch.rand(n, self.dim, device=get_device())
 
 
 # ======================================================================
@@ -106,9 +106,9 @@ class KdV_Regression:
         k = sqrt_c / 2.0
         return torch.cat([du_dz * k, du_dz * (-k * self.c)], dim=1)
 
-    def get_train_data(self, n_samples=5000):
-        x_space = torch.rand(n_samples, 1, device=device) * 4 - 2
-        t_time = torch.rand(n_samples, 1, device=device) * 0.1
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_space = torch.rand(n_pde, 1, device=get_device()) * 4 - 2
+        t_time = torch.rand(n_pde, 1, device=get_device()) * 0.1
         x_pde = torch.cat([x_space, t_time], dim=1)
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
@@ -117,8 +117,8 @@ class KdV_Regression:
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=10000):
-        x_space = torch.rand(n, 1, device=device) * 4 - 2
-        t_time = torch.rand(n, 1, device=device) * 0.1
+        x_space = torch.rand(n, 1, device=get_device()) * 4 - 2
+        t_time = torch.rand(n, 1, device=get_device()) * 0.1
         return torch.cat([x_space, t_time], dim=1)
 
 
@@ -153,9 +153,9 @@ class ReactionDiffusion_Regression:
         du_dz = -2.0 * ((1.0 + E).pow(-3)) * E
         return torch.cat([du_dz * alpha, du_dz * (-alpha * c)], dim=1)
 
-    def get_train_data(self, n_samples=5000):
-        x_space = torch.rand(n_samples, 1, device=device) * 20 - 10
-        t_time = torch.rand(n_samples, 1, device=device)
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_space = torch.rand(n_pde, 1, device=get_device()) * 20 - 10
+        t_time = torch.rand(n_pde, 1, device=get_device())
         x_pde = torch.cat([x_space, t_time], dim=1)
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
@@ -164,8 +164,8 @@ class ReactionDiffusion_Regression:
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=10000):
-        x_space = torch.rand(n, 1, device=device) * 20 - 10
-        t_time = torch.rand(n, 1, device=device)
+        x_space = torch.rand(n, 1, device=get_device()) * 20 - 10
+        t_time = torch.rand(n, 1, device=get_device())
         return torch.cat([x_space, t_time], dim=1)
 
 
@@ -205,9 +205,9 @@ class SineGordon_Regression:
         dA_dt = (1.0 / denom) * (k * w * cos_wt)
         return torch.cat([du_dA * dA_dx, du_dA * dA_dt], dim=1)
 
-    def get_train_data(self, n_samples=5000):
-        x_space = torch.rand(n_samples, 1, device=device) * 20 - 10
-        t_time = torch.rand(n_samples, 1, device=device) * 20
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_space = torch.rand(n_pde, 1, device=get_device()) * 20 - 10
+        t_time = torch.rand(n_pde, 1, device=get_device()) * 20
         x_pde = torch.cat([x_space, t_time], dim=1)
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
@@ -216,8 +216,8 @@ class SineGordon_Regression:
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=2000):
-        x_space = torch.rand(n, 1, device=device) * 20 - 10
-        t_time = torch.rand(n, 1, device=device) * 20
+        x_space = torch.rand(n, 1, device=get_device()) * 20 - 10
+        t_time = torch.rand(n, 1, device=get_device()) * 20
         return torch.cat([x_space, t_time], dim=1)
 
 
@@ -245,9 +245,9 @@ class KleinGordon_Regression:
         du_dt = -2 * np.pi * torch.sin(np.pi * xv) * torch.sin(2 * np.pi * tv)
         return torch.cat([du_dx, du_dt], dim=1)
 
-    def get_train_data(self, n_samples=5000):
-        x_space = torch.rand(n_samples, 1, device=device) * 2 - 1
-        t_time = torch.rand(n_samples, 1, device=device)
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_space = torch.rand(n_pde, 1, device=get_device()) * 2 - 1
+        t_time = torch.rand(n_pde, 1, device=get_device())
         x_pde = torch.cat([x_space, t_time], dim=1)
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
@@ -256,8 +256,8 @@ class KleinGordon_Regression:
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=2000):
-        x_space = torch.rand(n, 1, device=device) * 2 - 1
-        t_time = torch.rand(n, 1, device=device)
+        x_space = torch.rand(n, 1, device=get_device()) * 2 - 1
+        t_time = torch.rand(n, 1, device=get_device())
         return torch.cat([x_space, t_time], dim=1)
 
 
@@ -290,9 +290,9 @@ class NavierStokes2D_Kovasznay:
         du_dy = 2 * np.pi * exp_term * sin_term
         return torch.cat([du_dx, du_dy], dim=1)
 
-    def get_train_data(self, n_samples=5000):
-        x_space = torch.rand(n_samples, 1, device=device) * 1.5 - 0.5
-        y_space = torch.rand(n_samples, 1, device=device) * 2.0 - 0.5
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_space = torch.rand(n_pde, 1, device=get_device()) * 1.5 - 0.5
+        y_space = torch.rand(n_pde, 1, device=get_device()) * 2.0 - 0.5
         x_pde = torch.cat([x_space, y_space], dim=1)
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
@@ -301,8 +301,8 @@ class NavierStokes2D_Kovasznay:
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=2000):
-        x_space = torch.rand(n, 1, device=device) * 1.5 - 0.5
-        y_space = torch.rand(n, 1, device=device) * 2.0 - 0.5
+        x_space = torch.rand(n, 1, device=get_device()) * 1.5 - 0.5
+        y_space = torch.rand(n, 1, device=get_device()) * 2.0 - 0.5
         return torch.cat([x_space, y_space], dim=1)
 
 
@@ -332,8 +332,8 @@ class GrayScott_Pulse:
         darg_dt = 2 * self.c * (xv - self.c * tv) / self.sigma
         return torch.cat([u * darg_dx, u * darg_dt], dim=1)
 
-    def get_train_data(self, n_samples=5000):
-        x_pde = torch.rand(n_samples, 2, device=device)
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_pde = torch.rand(n_pde, 2, device=get_device())
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
 
@@ -341,7 +341,7 @@ class GrayScott_Pulse:
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=2000):
-        return torch.rand(n, 2, device=device)
+        return torch.rand(n, 2, device=get_device())
 
 
 # ======================================================================
@@ -358,8 +358,8 @@ class Bratu2D_Regression(Bratu2D):
         super().__init__(lam=1.0)
         self.name = "Bratu 2D (Reg)"
 
-    def get_train_data(self, n_samples=5000):
-        x_pde = torch.rand(n_samples, 2, device=device)
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_pde = torch.rand(n_pde, 2, device=get_device())
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
 
@@ -367,7 +367,7 @@ class Bratu2D_Regression(Bratu2D):
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=5000):
-        return torch.rand(n, 2, device=device)
+        return torch.rand(n, 2, device=get_device())
 
 
 # ======================================================================
@@ -385,8 +385,8 @@ class NLHelmholtz2D_Regression(NLHelmholtz2D):
         super().__init__(k=3.0, alpha=0.5)
         self.name = "NL-Helmholtz (Reg)"
 
-    def get_train_data(self, n_samples=5000):
-        x_pde = torch.rand(n_samples, 2, device=device)
+    def get_train_data(self, n_pde=5000, n_bc=0):
+        x_pde = torch.rand(n_pde, 2, device=get_device())
         u_true = self.exact(x_pde)
         return x_pde, [(x_pde, u_true, "data_fit")]
 
@@ -394,4 +394,4 @@ class NLHelmholtz2D_Regression(NLHelmholtz2D):
         return _regression_build(slv, x_pde, bcs)
 
     def get_test_points(self, n=5000):
-        return torch.rand(n, 2, device=device)
+        return torch.rand(n, 2, device=get_device())

--- a/fastlsq/tuning.py
+++ b/fastlsq/tuning.py
@@ -58,6 +58,7 @@ def auto_select_scale(
 
     best_scale = scales[0]
     best_error = float("inf")
+    last_exc = None
     n_outputs = getattr(problem, "n_outputs", 1)
 
     for scale in scales:
@@ -108,7 +109,8 @@ def auto_select_scale(
                 if np.isnan(val_err) or np.isinf(val_err):
                     val_err = 1e10
                 errors.append(val_err)
-            except Exception:
+            except Exception as e:
+                last_exc = e
                 errors.append(1e10)
 
         mean_error = np.mean(errors)
@@ -119,4 +121,10 @@ def auto_select_scale(
             best_error = mean_error
             best_scale = scale
 
+    if best_error >= 1e10:
+        msg = ("auto_select_scale: no scale produced a finite error; every "
+               "trial failed or diverged")
+        if last_exc is not None:
+            msg += f" (last exception: {last_exc!r})"
+        raise RuntimeError(msg)
     return best_scale

--- a/fastlsq/vector.py
+++ b/fastlsq/vector.py
@@ -356,11 +356,11 @@ class VectorFastLSQSolver:
     ):
         """Append a feature block to every component.
 
-        If `scale` is a list/tuple of length ``n_components``, each
+        If `scale` is a list/tuple/ndarray of length ``n_components``, each
         component is scaled independently.  Otherwise the same scale
         is shared.
         """
-        if isinstance(scale, (list, tuple)) and \
+        if isinstance(scale, (list, tuple, np.ndarray)) and \
            len(scale) == self._n_components and \
            not isinstance(scale[0], (list, tuple, np.ndarray)):
             scales = list(scale)


### PR DESCRIPTION
- learnable: replace NaN-grad SVD backward with gelsd lstsq (bandwidth training works)
- ElasticWave2D: scale spatial+cross terms by t_max² (val_err ~1.4 → ~1e-2)
- linalg: tighten auto-solve Cholesky accept threshold (rcond^0.5 → rcond^0.25)
- newton/api: relative residual stop test; reject worse line-search step; looser tol defaults
- api: guard continuation when nu_target is None
- regression: get_train_data(n_pde,n_bc) signature; tuning raises when all scales fail
- basis: cast inputs to working dtype (fix float32 crash)
- export: load_checkpoint with weights_only=False
- vector: accept ndarray per-component scale
- problems: use live get_device() instead of import-time snapshot
- example: orbit_hill solves via rank-revealing lstsq, not normal-equations Cholesky