### PR TITLE
fix: Σ-learner trained uphill; use exact envelope gradient (v0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 All notable changes to FastLSQ will be documented in this file.
 
+## [0.4.3] - 2026-07-20
+
+### Fixed
+
+- **Bandwidth training ran *uphill*.** `train_bandwidth` / `LearnableFastLSQ.fit`
+  backpropagated the outer residual through `torch.linalg.lstsq`, whose backward
+  goes through `(Aᵀ A)⁻¹`. Random-feature systems sit at `cond(A) ~ 1e11`, so
+  `cond(AᵀA) ~ 1e22` overruns float64 and the gradient came back as noise — wrong
+  sign, ~1e7 relative error, and different on every run. On the anisotropic Poisson
+  benchmark Σ moved the wrong way on *both* axes (`σx` 25→2.6 where the optimum is
+  37.7; `σy` 25→66 where the optimum is 3.14), the training loss climbed 8 orders of
+  magnitude, and `fit()` reliably returned a *worse* solution than its own isotropic
+  starting point. The outer loss now differentiates through `A(L)` only, with `beta*`
+  detached: since `beta*` minimises the inner problem, `r ⟂ range(A)` and the
+  `dbeta*/dL` term vanishes identically, so this is the **exact** gradient
+  (envelope / Danskin), not an approximation — and it is ~6x faster, since the
+  backward no longer traverses an SVD. Learned Σ now beats the fixed isotropic by
+  **600x–33000x** (rel. L2 `~2e-4` → `~5e-8`) across seeds, in both `diagonal` and
+  `cholesky` modes. The forward solve was never affected: `gelsd` is rank-revealing
+  and backward-stable.
+- **Best-iterate restore was off by one.** `train_bandwidth` snapshotted
+  `best_params` *after* `optimizer.step()`, storing `L_{t+1}` under `loss(L_t)`, so
+  the "best" iterate it restored was the step *after* the best one — which on a
+  diverging run is exactly the wrong parameter set. The history's `sigma` /
+  `cov_diag` were likewise one step ahead of the `loss` reported beside them. Both
+  are now captured before the optimiser moves.
+
+### Added
+
+- **`residual_loss(learnable, A, b)`** — the outer training objective, factored out
+  of `train_bandwidth` and exported, so the envelope-theorem gradient is testable
+  (and reusable) rather than inlined in the loop.
+- **Gradient regression test** — `test_bandwidth_gradient_matches_finite_differences`
+  checks the outer gradient against central differences in ~20 s, catching an uphill
+  optimiser directly instead of waiting on a 150-step end-to-end run. The two
+  `train_bandwidth` end-to-end tests passed throughout the regression: with a noise
+  gradient the loop degenerates into a random search that keeps a best iterate, and
+  on those draws it still stumbled into the required 10x win.
+
+### Changed
+
+- **`test_fit_beats_isotropic_solve` now requires a decisive margin** (10x) rather
+  than a bare `<`. The learned and isotropic errors are evaluated on *different*
+  test-point sets, so a bare `<` was within sampling noise of a tie; the measured
+  margin after the gradient fix is 600x–33000x. Its test points are now seeded —
+  previously they were drawn from whatever RNG state the preceding test left behind,
+  so the test was not reproducible when run standalone.
+
 ## [0.4.1] - 2026-06-23
 
 ### Added

--- a/fastlsq/__init__.py
+++ b/fastlsq/__init__.py
@@ -28,7 +28,7 @@ from fastlsq.linalg import solve_lstsq
 from fastlsq.block import block_concat, pack_beta, unpack_beta
 from fastlsq.api import solve_linear, solve_nonlinear
 from fastlsq.tuning import auto_select_scale
-from fastlsq.learnable import LearnableFastLSQ, train_bandwidth
+from fastlsq.learnable import LearnableFastLSQ, train_bandwidth, residual_loss
 from fastlsq.plotting import (
     plot_solution_1d,
     plot_solution_2d_slice,
@@ -55,7 +55,7 @@ from fastlsq.export import (
 from fastlsq import viz
 from fastlsq import benchmark
 
-__version__ = "0.4.1"
+__version__ = "0.4.3"
 __all__ = [
     # Device selection (CPU / CUDA / Apple-MPS, dtype-aware)
     "resolve_device",
@@ -86,6 +86,7 @@ __all__ = [
     # Learnable bandwidth
     "LearnableFastLSQ",
     "train_bandwidth",
+    "residual_loss",
     # High-level API
     "solve_linear",
     "solve_nonlinear",

--- a/fastlsq/learnable.py
+++ b/fastlsq/learnable.py
@@ -16,7 +16,9 @@ Key ideas
   triangular matrix (or a scalar multiple of the identity).
 * **Inner exact solve** -- for each L, the PDE matrix A(L) is assembled
   analytically via the cyclic derivative formula and beta*(L) = A(L)^+ b
-  is computed in one shot.  Gradients flow back through `torch.linalg.lstsq`.
+  is computed in one shot.  The outer loss differentiates through A(L) only:
+  beta* is optimal, so the envelope theorem makes its derivative drop out and
+  the gradient never touches the (numerically hopeless) lstsq backward.
 * **Learnable operator coefficients** -- Op accepts nn.Parameter in scalar
   multiplication, e.g. ``Op.laplacian(d=2) + k**2 * Op.identity(d=2)`` with
   ``k = nn.Parameter(...)``.  Build the operator inside forward() so it
@@ -192,16 +194,20 @@ class LearnableFastLSQ(nn.Module):
 
     def solve_inner(self, A: torch.Tensor, b: torch.Tensor, mu: float = 0.0,
                     rcond: float = 1e-12):
-        """Differentiable rank-revealing inner solve.
+        """Rank-revealing inner solve.
 
         Solves ``beta* = argmin ||A beta - b||^2 + mu ||beta||^2`` through the
         SVD-based ``gelsd`` least-squares driver with ``rcond`` truncation, so
-        gradients still flow back to ``L`` *and* the solve is stable when ``A``
-        is rank-deficient.  (The ``rcond`` cut suppresses the near-null space,
-        and ``gelsd``'s backward uses the stable pseudoinverse formula rather
-        than per-singular-vector derivatives -- which is what keeps the outer
-        AdamW loop's gradients finite.  A plain ``torch.linalg.lstsq`` *without*
-        ``rcond`` is what amplifies the null space.)
+        the solve stays stable when ``A`` is rank-deficient (the ``rcond`` cut
+        suppresses the near-null space that a plain ``torch.linalg.lstsq``
+        would amplify).
+
+        The returned ``beta`` carries a grad_fn, but **do not backpropagate
+        through it**: lstsq's backward needs ``(A^T A)^-1``, and random-feature
+        systems reach ``cond(A) ~ 1e11``, so the squared condition number
+        overruns float64 and the gradient comes back as noise.  Differentiate
+        the residual with ``beta`` detached instead -- that is exact, not an
+        approximation (see :func:`train_bandwidth`).
 
         For ``n_outputs > 1`` the system is block-stacked: the flat solution is
         kept as ``self._beta_flat`` (shape-compatible with ``A``) for residual
@@ -266,6 +272,41 @@ class LearnableFastLSQ(nn.Module):
 # Training loop
 # ======================================================================
 
+def residual_loss(learnable: LearnableFastLSQ, A: torch.Tensor,
+                  b_rhs: torch.Tensor) -> torch.Tensor:
+    """Outer loss ``mean((A beta* - b)^2)``, differentiable in the bandwidth.
+
+    ``beta*`` is **detached on purpose**.  It minimises the inner least-squares
+    problem, so the residual ``r = A beta* - b`` is orthogonal to ``range(A)``,
+    ``r^T A dbeta*/dL`` vanishes identically, and
+
+        dLoss/dL = 2 r^T (dA/dL beta* - db/dL)
+
+    is the *exact* total derivative with ``beta*`` held fixed (envelope /
+    Danskin theorem) -- not an approximation.
+
+    Differentiating through the inner solve instead is not merely redundant, it
+    is wrong here: ``torch.linalg.lstsq``'s backward needs ``(A^T A)^-1``, and
+    these random-feature systems run at ``cond(A) ~ 1e11``, so ``cond(A^T A) ~
+    1e22`` sits far past float64's ``~1e16``.  The gradient came back as
+    numerical noise -- wrong sign, ~1e7 relative error, and not reproducible
+    between runs -- which sent AdamW *up*hill and made ``fit()`` reliably worse
+    than its own isotropic starting point.  The forward solve is unaffected:
+    ``gelsd`` is rank-revealing and backward-stable.
+
+    Ridge caveat: with ``mu > 0`` the inner solve returns the *ridge* minimiser,
+    for which ``A^T r = -mu beta*``, so the identity above is off by exactly
+    ``mu d||beta*||^2/dL`` -- nil at the default ``mu = 0``, and negligible at
+    the small ridges used in practice (``mu ~ 1e-10``).  It vanishes outright if
+    the loss is taken to be the full inner objective ``||A beta - b||^2 + mu
+    ||beta||^2``, which is the quantity ``beta*`` actually minimises.
+
+    ``_beta_flat`` (not ``beta``) is used because it stays block-stacked and
+    shape-compatible with ``A`` when ``n_outputs > 1``.
+    """
+    return torch.mean((A @ learnable._beta_flat.detach() - b_rhs) ** 2)
+
+
 def train_bandwidth(
     learnable: LearnableFastLSQ,
     problem,
@@ -279,11 +320,12 @@ def train_bandwidth(
     clip_grad: float = 10.0,
     verbose: bool = True,
 ) -> list[dict]:
-    """Hybrid training: differentiable inner solve + outer AdamW on the bandwidth.
+    """Hybrid training: exact inner solve + outer AdamW on the bandwidth.
 
     At each step the PDE matrix ``A(L)`` is assembled, ``beta*(L)`` is solved by a
-    **rank-revealing** (truncated-SVD) inner solve, and the outer loss
-    ``||A beta* - b||^2`` is backpropagated to ``L``.  The loop is robust:
+    **rank-revealing** (truncated-SVD) inner solve, and :func:`residual_loss` is
+    backpropagated to ``L`` -- through ``A(L)`` only, since ``beta*`` is optimal
+    and the envelope theorem makes its derivative drop out.  The loop is robust:
     gradients are clipped, the best iterate is retained, and a failed inner SVD
     stops training gracefully.  Defaults (``mu=0``, ``lr=0.1``) match the
     validated diagonal/cholesky configuration.
@@ -316,9 +358,7 @@ def train_bandwidth(
             if verbose:
                 print(f"  Step {step:4d}: inner SVD failed -- stopping.")
             break
-        # _beta_flat is block-stacked and shape-compatible with A (for n_outputs>1);
-        # learnable.beta may be reshaped to (N, k), so the loss uses _beta_flat.
-        loss = torch.mean((A @ learnable._beta_flat - b_rhs) ** 2)
+        loss = residual_loss(learnable, A, b_rhs)
         if not torch.isfinite(loss):
             if verbose:
                 print(f"  Step {step:4d}: non-finite loss -- stopping.")
@@ -329,21 +369,27 @@ def train_bandwidth(
             if verbose:
                 print(f"  Step {step:4d}: non-finite gradient -- stopping.")
             break
-        if clip_grad:
-            torch.nn.utils.clip_grad_norm_(learnable.parameters(), clip_grad)
-        optimizer.step()
 
+        # Snapshot the iterate that *produced* this loss -- i.e. before the
+        # optimiser moves it.  Capturing after optimizer.step() stored L_{t+1}
+        # under loss(L_t), so a diverging run restored the step-after-best
+        # parameters instead of the best ones.
         l = loss.item()
         if l < best_loss:
             best_loss = l
             best_params = {n: p.detach().clone() for n, p in learnable.named_parameters()}
 
+        # ... and report the sigma that produced it, for the same reason.
         info = {"step": step, "loss": l, "sigma": learnable.sigma.item()}
         if learnable.mode == "cholesky":
             info["cov_diag"] = torch.diagonal(learnable.covariance).detach().cpu().tolist()
         history.append(info)
         if verbose and step % max(1, n_steps // 20) == 0:
             print(f"  Step {step:4d}: loss={l:.4e}  sigma={info['sigma']:.4f}")
+
+        if clip_grad:
+            torch.nn.utils.clip_grad_norm_(learnable.parameters(), clip_grad)
+        optimizer.step()
 
     # restore the best iterate and re-solve beta at it
     if best_params is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FastLSQ"
-version = "0.4.1"
+version = "0.4.3"
 description = "One-shot PDE solving via Fourier features with exact analytical derivatives; rank-revealing solvers, learnable anisotropic bandwidth, and CPU/CUDA/MPS support"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_learnable.py
+++ b/tests/test_learnable.py
@@ -9,7 +9,7 @@ import torch
 torch.set_default_dtype(torch.float64)
 
 from fastlsq import solve_linear
-from fastlsq.learnable import LearnableFastLSQ, train_bandwidth
+from fastlsq.learnable import LearnableFastLSQ, train_bandwidth, residual_loss
 from fastlsq.geometry import sample_box, sample_boundary_box
 
 PI = math.pi
@@ -77,8 +77,9 @@ def test_learn_anisotropic_bandwidth(mode):
 
 def test_fit_beats_isotropic_solve():
     prob = AnisoPoisson()
-    xt = prob.get_test_points(2000)
-    ut = prob.exact(xt)
+    torch.manual_seed(7)                       # seed the test points too: without
+    xt = prob.get_test_points(2000)            # this the draw depends on whatever
+    ut = prob.exact(xt)                        # ran before, so runs are not reproducible
     torch.manual_seed(0)
     iso = solve_linear(prob, scale=25.0, auto_scale=False, n_blocks=1,
                        hidden_size=500, n_pde=3000, n_bc=800, n_test=2000, verbose=False)
@@ -87,7 +88,54 @@ def test_fit_beats_isotropic_solve():
                           normalize=False).fit(prob, n_pde=3000, n_bc=800,
                                                n_steps=150, verbose=False)
     learned_err = _rel(lm.predict(xt), ut)
-    assert learned_err < iso["metrics"]["val_err"]
+    # Same features, same collocation data, same solve: this isolates the learned
+    # Sigma.  A bare `<` would also be satisfied by measurement noise -- the two
+    # errors are evaluated on different point sets -- so require a decisive win.
+    # Measured margin is 600x-33000x over seeds 0-4; 10x leaves ample headroom.
+    assert learned_err < iso["metrics"]["val_err"] / 10.0, (
+        f"learned {learned_err:.2e} vs isotropic {iso['metrics']['val_err']:.2e}")
+
+
+def test_bandwidth_gradient_matches_finite_differences():
+    """The outer loss gradient must point downhill.
+
+    ``residual_loss`` -- what ``train_bandwidth`` optimises -- differentiates
+    ``||A(L) beta* - b||^2`` with ``beta*`` detached, which the envelope theorem
+    makes exact.  Backpropagating through the inner ``lstsq`` instead needs
+    ``(A^T A)^-1``, and at ``cond(A) ~ 1e11`` that overruns float64 and returns
+    noise -- which silently sent the optimiser uphill.  This catches that
+    directly, and in seconds rather than 150 training steps.
+    """
+    torch.manual_seed(0)
+    prob = AnisoPoisson()
+    lm = LearnableFastLSQ(2, n_features=500, mode="cholesky", init_scale=25.0,
+                          normalize=False)
+    x, bc, f = prob.get_train_data(3000, 800)
+
+    def loss_at(L_raw):
+        with torch.no_grad():
+            lm.L_raw.copy_(L_raw)
+        A, b = prob.build(lm, x, bc, f)
+        lm.solve_inner(A, b)
+        return residual_loss(lm, A, b)
+
+    p0 = lm.L_raw.detach().clone()
+    loss_at(p0).backward()
+    g = lm.L_raw.grad.detach().clone()
+
+    h = 0.01
+    for i, j in [(0, 0), (1, 0), (1, 1)]:       # strictly-lower + diagonal
+        pp, pm = p0.clone(), p0.clone()
+        pp[i, j] += h
+        pm[i, j] -= h
+        with torch.no_grad():
+            fd = (loss_at(pp) - loss_at(pm)).item() / (2 * h)
+        assert torch.sign(g[i, j]) == math.copysign(1.0, fd), (
+            f"L_raw[{i},{j}]: autograd {g[i, j]:.3e} disagrees in sign with FD {fd:.3e}"
+        )
+        assert abs(g[i, j].item() - fd) <= 0.05 * abs(fd), (
+            f"L_raw[{i},{j}]: autograd {g[i, j]:.3e} vs FD {fd:.3e}"
+        )
 
 
 def test_covariance_is_psd():

--- a/tests/test_vector_basis.py
+++ b/tests/test_vector_basis.py
@@ -20,7 +20,7 @@ from fastlsq.utils import device
 # ----------------------------------------------------------------------
 
 def test_version():
-    assert fastlsq.__version__ == "0.4.1"
+    assert fastlsq.__version__ == "0.4.3"
 
 
 def test_imports():


### PR DESCRIPTION
Backprop through torch.linalg.lstsq squares cond(A)~1e11 past float64, so the bandwidth gradient was noise (wrong sign, non-reproducible) and fit() returned worse-than-isotropic. Detach beta*: r ⟂ range(A) makes that exact, and 6x faster. Also fix best_params being snapshotted after optimizer.step(). Learned Σ now beats isotropic by 600x-33000x.