### PR TITLE
fix: Σ-learner trained uphill; use the exact envelope gradient (v0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to FastLSQ will be documented in this file.
 
+## [0.4.3] - 2026-07-20
+
+### Fixed
+
+- **The Σ-learner trained uphill: `train_bandwidth` now uses the exact envelope
+  gradient.** The outer loss was backpropagated *through* `torch.linalg.lstsq`,
+  whose backward carries a `(AᵀA)⁻¹` and therefore squares `cond(A)`. For a
+  routine collocation system (`cond(A) ≈ 2.2e11` on the `AnisoPoisson` benchmark)
+  that needs ~5e22 of dynamic range, far past float64. Measured against central
+  finite differences at the isotropic init, the resulting "gradient" was **4.3e6×
+  too large with `cos(angle) = −0.707`** — an *ascent* direction, which `AdamW`
+  duly followed (`clip_grad` rescaled the magnitude but preserved the direction).
+  `fit()` consequently returned a solution ~3.6× *worse* than the isotropic
+  `solve_linear` baseline it is meant to beat.
+
+  The inner solve is now performed under `no_grad` and only the assembled `A(L)`
+  is differentiated. This is **exact, not an approximation**: for
+  `J(L) = ‖A(L)β* − b‖²` the chain-rule contribution through `β*` is
+  `2 (Aᵀr)ᵀ dβ*/dL`, and `Aᵀr = 0` at the least-squares optimum (the residual is
+  orthogonal to `range(A)`), so the term vanishes identically and
+  `dJ/dL = 2 rᵀ (dA/dL) β*` — the envelope (Danskin) theorem. The detached
+  gradient matches finite differences to **1.2e-3 relative, `cos(angle) = 1.0000`**,
+  and skips the ill-conditioned backward entirely.
+
+  On the `AnisoPoisson` benchmark the training loss now descends monotonically
+  (`1.9e-3` → `9.8e-11`) instead of climbing (`1.9e-3` → `1.2e+05`), an
+  independent held-out collocation draw tracks it the whole way (no overfitting),
+  and the learned Σ reaches `4.4e-8` against the isotropic `solve_linear`
+  baseline's `1.9e-4` — **~4350× better**, where it was previously ~3.6× *worse*.
+  Not backpropagating through the solve also makes each step ~6× cheaper
+  (`tests/test_learnable.py`: 389s → 57s).
+
+  Note this is the *third* attempt at this bug (see 0.2.1 and 0.2.2): both earlier
+  fixes swapped the inner solve's driver (`svd` → rank-revealing `gelsd`) to stop
+  the gradient being `NaN`. That made it **finite but never correct** — the loop
+  still differentiated through the solve. Differentiating through an
+  ill-conditioned least-squares solve is not stabilisable by choice of driver;
+  the envelope identity removes the need to do it at all.
+- **`train_bandwidth` restored the wrong "best" iterate.** `best_params` was
+  snapshotted *after* `optimizer.step()`, so it stored `θ_{t+1}` while recording
+  `loss(θ_t)` — the best-iterate restore returned the successor of the best
+  iterate. The snapshot (and the `history` entry's `sigma` / `cov_diag`, which had
+  the same off-by-one) now happens before the step, so all three describe the same
+  point.
+
 ## [0.4.2] - 2026-07-20
 
 ### Fixed

--- a/fastlsq/__init__.py
+++ b/fastlsq/__init__.py
@@ -55,7 +55,7 @@ from fastlsq.export import (
 from fastlsq import viz
 from fastlsq import benchmark
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __all__ = [
     # Device selection (CPU / CUDA / Apple-MPS, dtype-aware)
     "resolve_device",

--- a/fastlsq/learnable.py
+++ b/fastlsq/learnable.py
@@ -16,7 +16,10 @@ Key ideas
   triangular matrix (or a scalar multiple of the identity).
 * **Inner exact solve** -- for each L, the PDE matrix A(L) is assembled
   analytically via the cyclic derivative formula and beta*(L) = A(L)^+ b
-  is computed in one shot.  Gradients flow back through `torch.linalg.lstsq`.
+  is computed in one shot.  The outer gradient does *not* backpropagate
+  through that solve: by the envelope theorem the beta* term drops out
+  (A^T r = 0), so `train_bandwidth` detaches beta* and differentiates only
+  the assembled A(L).  This is exact and avoids lstsq's cond(A)^2 backward.
 * **Learnable operator coefficients** -- Op accepts nn.Parameter in scalar
   multiplication, e.g. ``Op.laplacian(d=2) + k**2 * Op.identity(d=2)`` with
   ``k = nn.Parameter(...)``.  Build the operator inside forward() so it
@@ -196,12 +199,17 @@ class LearnableFastLSQ(nn.Module):
 
         Solves ``beta* = argmin ||A beta - b||^2 + mu ||beta||^2`` through the
         SVD-based ``gelsd`` least-squares driver with ``rcond`` truncation, so
-        gradients still flow back to ``L`` *and* the solve is stable when ``A``
-        is rank-deficient.  (The ``rcond`` cut suppresses the near-null space,
-        and ``gelsd``'s backward uses the stable pseudoinverse formula rather
-        than per-singular-vector derivatives -- which is what keeps the outer
-        AdamW loop's gradients finite.  A plain ``torch.linalg.lstsq`` *without*
-        ``rcond`` is what amplifies the null space.)
+        the solve is stable when ``A`` is rank-deficient (the ``rcond`` cut
+        suppresses the near-null space).
+
+        .. warning::
+           This is autograd-traceable, but do **not** rely on backpropagating
+           through it to fit the bandwidth.  ``lstsq``'s backward carries a
+           ``(A^T A)^-1``, squaring ``cond(A)``; for a typical collocation
+           system (``cond ~ 1e11``) that is ~1e22 and the returned gradient is
+           numerical noise pointing in the wrong direction.  :func:`train_bandwidth`
+           deliberately solves under ``no_grad`` and relies on the envelope
+           theorem instead -- see its inline note.
 
         For ``n_outputs > 1`` the system is block-stacked: the flat solution is
         kept as ``self._beta_flat`` (shape-compatible with ``A``) for residual
@@ -311,28 +319,36 @@ def train_bandwidth(
         optimizer.zero_grad()
         A, b_rhs = problem.build(learnable, x_pde, bcs, f_pde)
         try:
-            learnable.solve_inner(A, b_rhs, mu=mu, rcond=rcond)
+            # beta* is solved under no_grad, i.e. *detached* from L, on purpose.
+            # At the least-squares optimum the residual r = A beta* - b is
+            # orthogonal to range(A), so the chain-rule term through beta* is
+            # (dJ/dbeta)^T dbeta*/dL = 2 (A^T r)^T dbeta*/dL = 0 and the total
+            # derivative collapses to the partial one (envelope theorem):
+            #     dJ/dL = 2 r^T (dA/dL) beta*.
+            # Detaching is therefore *exact*, not an approximation -- and it is
+            # the only usable route: lstsq's backward carries a (A^T A)^-1, which
+            # squares cond(A) (~2e11 for this problem, so ~5e22) far past what
+            # float64 can represent.  Backpropagating through the solve yields a
+            # "gradient" ~1e6x too large that points uphill (cos ~ -0.7 against
+            # finite differences), which trained the bandwidth the wrong way.
+            with torch.no_grad():
+                learnable.solve_inner(A, b_rhs, mu=mu, rcond=rcond)
         except torch.linalg.LinAlgError:
             if verbose:
                 print(f"  Step {step:4d}: inner SVD failed -- stopping.")
             break
         # _beta_flat is block-stacked and shape-compatible with A (for n_outputs>1);
         # learnable.beta may be reshaped to (N, k), so the loss uses _beta_flat.
+        # A keeps its graph, so dJ/dL still flows through the assembled operator.
         loss = torch.mean((A @ learnable._beta_flat - b_rhs) ** 2)
         if not torch.isfinite(loss):
             if verbose:
                 print(f"  Step {step:4d}: non-finite loss -- stopping.")
             break
-        loss.backward()
-        if any(p.grad is not None and not torch.isfinite(p.grad).all()
-               for p in learnable.parameters()):
-            if verbose:
-                print(f"  Step {step:4d}: non-finite gradient -- stopping.")
-            break
-        if clip_grad:
-            torch.nn.utils.clip_grad_norm_(learnable.parameters(), clip_grad)
-        optimizer.step()
 
+        # Record the loss *and* snapshot the parameters before optimizer.step():
+        # both describe the current iterate.  Snapshotting afterwards saved the
+        # successor of the best iterate rather than the best one itself.
         l = loss.item()
         if l < best_loss:
             best_loss = l
@@ -344,6 +360,16 @@ def train_bandwidth(
         history.append(info)
         if verbose and step % max(1, n_steps // 20) == 0:
             print(f"  Step {step:4d}: loss={l:.4e}  sigma={info['sigma']:.4f}")
+
+        loss.backward()
+        if any(p.grad is not None and not torch.isfinite(p.grad).all()
+               for p in learnable.parameters()):
+            if verbose:
+                print(f"  Step {step:4d}: non-finite gradient -- stopping.")
+            break
+        if clip_grad:
+            torch.nn.utils.clip_grad_norm_(learnable.parameters(), clip_grad)
+        optimizer.step()
 
     # restore the best iterate and re-solve beta at it
     if best_params is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FastLSQ"
-version = "0.4.2"
+version = "0.4.3"
 description = "One-shot PDE solving via Fourier features with exact analytical derivatives; rank-revealing solvers, learnable anisotropic bandwidth, and CPU/CUDA/MPS support"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_vector_basis.py
+++ b/tests/test_vector_basis.py
@@ -20,7 +20,7 @@ from fastlsq.utils import device
 # ----------------------------------------------------------------------
 
 def test_version():
-    assert fastlsq.__version__ == "0.4.2"
+    assert fastlsq.__version__ == "0.4.3"
 
 
 def test_imports():


### PR DESCRIPTION
train_bandwidth backpropagated the outer loss through torch.linalg.lstsq, whose backward carries a (A^T A)^-1 and so squares cond(A). At cond(A)=2.2e11 (AnisoPoisson) that needs ~5e22 of dynamic range against float64's ~1e16, so the bandwidth "gradient" was numerical noise: measured against central finite differences it was 4.3e6x too large with cos(angle) = -0.707, i.e. an ascent direction that AdamW duly followed. clip_grad rescaled the magnitude but preserved the direction. Observed directly: the loss climbs 1.9e-3 -> 1.2e+05, and the first step moves Sigma to [508, 758] -- shrinking the fast-x bandwidth and growing the slow-y one, exactly backwards for sin(12*pi*x)*sin(pi*y).

Solve beta* under no_grad and differentiate only the assembled A(L). This is exact, not an approximation: for J(L) = ||A(L)beta* - b||^2 the chain-rule term through beta* is 2 (A^T r)^T dbeta*/dL, and A^T r = 0 at the least-squares optimum (the residual is orthogonal to range(A)), so it vanishes identically and dJ/dL = 2 r^T (dA/dL) beta* -- the envelope (Danskin) theorem. The detached gradient matches finite differences to 1.2e-3 relative, cos(angle) = 1.0000.

Also fix a second, independent bug in the same loop: best_params was snapshotted after optimizer.step(), storing theta_{t+1} while recording loss(theta_t), so the best-iterate restore returned the successor of the best iterate. This produced the exact failing number -- the uphill run's best loss was at step 0, so the restore fell back to theta_1 rather than theta_0, giving 6.99e-4 instead of the init's 2.05e-4. The history entry's sigma/cov_diag had the same off-by-one and are now recorded at the same point.

Result on tests/test_learnable.py::test_fit_beats_isotropic_solve: the loss descends monotonically (1.9e-3 -> 9.8e-11), an independent held-out collocation draw tracks it the whole way (no overfitting), and the learned Sigma reaches 4.4e-8 against the isotropic solve_linear baseline's 1.9e-4 -- ~4350x better, where it was previously 3.6x worse. Not backpropagating through the solve also makes each step ~6x cheaper (test file: 389s -> 57s). Full suite: 105 passed.

Note this is the third attempt at this bug (0.2.1, 0.2.2); both earlier fixes swapped the inner solve's driver (svd -> rank-revealing gelsd) to stop the gradient being NaN, which made it finite but never correct because the loop still differentiated through the solve. Documented in the CHANGELOG so the fourth attempt does not reach for the driver again.